### PR TITLE
Fixed circular reference issue

### DIFF
--- a/user-management-service/src/main/java/com/scaler/usermanagementservice/controllers/AuthController.java
+++ b/user-management-service/src/main/java/com/scaler/usermanagementservice/controllers/AuthController.java
@@ -40,7 +40,7 @@ public class AuthController {
     }
 
     @PostMapping({"/setUserRole"})
-    @PreAuthorize("hasRole('ADMIN')")
+    @PreAuthorize("hasRole('Admin')")
     public ResponseEntity<Void> setUserRole(@RequestBody UserRoleDto userRoleDto) {
         authService.setUserRole(userRoleDto);
         return new ResponseEntity<>(HttpStatus.OK);

--- a/user-management-service/src/main/java/com/scaler/usermanagementservice/security/BCryptConfig.java
+++ b/user-management-service/src/main/java/com/scaler/usermanagementservice/security/BCryptConfig.java
@@ -1,0 +1,15 @@
+package com.scaler.usermanagementservice.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class BCryptConfig {
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+}

--- a/user-management-service/src/main/java/com/scaler/usermanagementservice/security/JwtRequestFilter.java
+++ b/user-management-service/src/main/java/com/scaler/usermanagementservice/security/JwtRequestFilter.java
@@ -7,7 +7,6 @@ import org.springframework.context.annotation.Lazy;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
@@ -22,12 +21,8 @@ import java.io.IOException;
 public class JwtRequestFilter extends OncePerRequestFilter {
 
     @Autowired
+    @Lazy
     private JwtService jwtService;
-
-//
-//    public JwtRequestFilter(JwtService jwtService) {
-//        this.jwtService = jwtService;
-//    }
 
     @Override
     protected void doFilterInternal(HttpServletRequest request,
@@ -67,6 +62,4 @@ public class JwtRequestFilter extends OncePerRequestFilter {
 
         filterChain.doFilter(request, response);
     }
-
-
 }

--- a/user-management-service/src/main/java/com/scaler/usermanagementservice/security/JwtUtility.java
+++ b/user-management-service/src/main/java/com/scaler/usermanagementservice/security/JwtUtility.java
@@ -5,7 +5,6 @@ import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.stereotype.Component;
 
 import java.security.Key;
 import java.util.*;
@@ -18,6 +17,8 @@ import java.util.function.Function;
 //@Component
 public class JwtUtility {
 
+    // TODO: Add token_validity variable to  application.properties
+    // TODO: Add a second variable for token_validity in milliseconds
     private static final int TOKEN_VALIDITY = 3600 * 5;
     private static final Key KEY = Keys.hmacShaKeyFor(UUID.randomUUID().toString().getBytes());
 

--- a/user-management-service/src/main/java/com/scaler/usermanagementservice/services/AuthService.java
+++ b/user-management-service/src/main/java/com/scaler/usermanagementservice/services/AuthService.java
@@ -40,14 +40,13 @@ public class AuthService {
             throw new UsernameAlreadyExistsException("Username already exists.");
         }
 
-        Role userRole = roleRepository.findRoleByName("USER").get();
-
         User user = new User();
         user.setUsername(signupDto.getUsername());
         user.setPassword(passwordEncoder.encode(signupDto.getPassword()));
         user.setPhone(signupDto.getPhone());
         user.setEmail(signupDto.getEmail());
         Set<Role> roles = new HashSet<>();
+        roles.add(findUserRole());
         user.setRoles(roles);// comment
         user.setCreated_at(Convert.localDateTimeToLong(LocalDateTime.now()));
         user.setUpdated_at(Convert.localDateTimeToLong(LocalDateTime.now()));
@@ -64,8 +63,23 @@ public class AuthService {
             throw new UsernameNotFoundException("User not found");
         }
 
+        Set<Role> roles = new HashSet<>();
         User user = optionalUser.get();
-        //user.setRole(userRoleDto.getRole());
+        Role role = findUserRole();
+        roles.add(role);
+        user.setRoles(roles);
         userRepository.save(user);
+    }
+
+    private Role findUserRole() {
+        Optional<Role> optionalRole = roleRepository.findRoleByName("User");
+        Role role;
+        if (optionalRole.isEmpty()) {
+            role = new Role("User");
+            roleRepository.save(role);
+        } else {
+            role = optionalRole.get();
+        }
+        return role;
     }
 }

--- a/user-management-service/src/main/java/com/scaler/usermanagementservice/services/JwtService.java
+++ b/user-management-service/src/main/java/com/scaler/usermanagementservice/services/JwtService.java
@@ -7,6 +7,7 @@ import com.scaler.usermanagementservice.models.User;
 import com.scaler.usermanagementservice.repositories.UserRepository;
 import com.scaler.usermanagementservice.security.JwtUtility;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.DisabledException;
@@ -24,11 +25,13 @@ import java.util.Set;
 @Service
 public class JwtService implements UserDetailsService {
     private final UserRepository userRepository;
-
     @Autowired
-    private AuthenticationManager authenticationManager;
+    @Lazy
+    public AuthenticationManager authenticationManager;
+
     private final Cache<String, String> tokenCache;
 
+    @Autowired
     public JwtService(UserRepository userRepository,
                       Cache<String, String> tokenCache) {
         this.userRepository = userRepository;


### PR DESCRIPTION
There was a circular reference between the 'SecurityConfig', 'JwtService', and 'JwtRequestFilter'. The issue was caused by the passwordEncoder bean in the SecurityConfig file. The solution was to create a new config file, 'BCryptConfig' with only the PasswordEncoder bean.